### PR TITLE
Fixed incompatibility with MicroG Project's UnifedNlp location services

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -201,12 +201,6 @@
         on the headphone/microphone jack. When false use the older uevent framework. -->
     <bool name="config_useDevInputEventForAudioJack">true</bool>
 
-    <!-- Enable overlay for all location components. -->
-    <bool name="config_enableNetworkLocationOverlay" translatable="false">false</bool>
-    <string name="config_networkLocationProviderPackageName" translatable="false">com.qualcomm.location</string>
-    <bool name="config_enableFusedLocationOverlay" translatable="false">false</bool>
-    <string name="config_fusedLocationProviderPackageName" translatable="false">com.qualcomm.location</string>
-
     <!-- Maximum number of supported users -->
     <integer name="config_multiuserMaximumUsers">4</integer>
 


### PR DESCRIPTION
I noticed after compiling for potter with this device tree, my UnifiedNlp location services weren't binding to the system - I removed this code and the issue was resolved.
See: https://forum.xda-developers.com/g5-plus/help/lineageos-microg-integration-t3710924

If this code was intentional, please let me know