### PR TITLE
potter: update callrecording overlay

### DIFF
--- a/overlay/packages/apps/Dialer/java/com/android/dialer/callrecord/res/values/config.xml
+++ b/overlay/packages/apps/Dialer/java/com/android/dialer/callrecord/res/values/config.xml
@@ -17,5 +17,4 @@
 -->
 <resources>
     <bool name="call_recording_enabled">true</bool>
-	<integer name="call_recording_audio_source">4</integer>
 </resources>


### PR DESCRIPTION
not needed as default value works for us

Change-Id: I0fdeaee2aaa4c1f6e32b2933c8f5c089583c5610